### PR TITLE
Allow numbers and strings to be cast to an Enum

### DIFF
--- a/src/MockDataStoreService.lua
+++ b/src/MockDataStoreService.lua
@@ -292,7 +292,7 @@ function DataStore:OnUpdate(key, callback)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'OnUpdate' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	return self.__event.Event:connect(function(k, v)
 		if k == key then
 			if YIELD_TIME_UPDATE_MAX > 0 then
@@ -301,7 +301,7 @@ function DataStore:OnUpdate(key, callback)
 			callback(deepcopy(v))
 		end
 	end)
-	
+
 end
 
 function DataStore:GetAsync(key)
@@ -312,15 +312,15 @@ function DataStore:GetAsync(key)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'GetAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local retValue = deepcopy(self.__data[key])
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return retValue
-	
+
 end
 
 function DataStore:IncrementAsync(key, delta)
@@ -333,32 +333,32 @@ function DataStore:IncrementAsync(key, delta)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'IncrementAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local old = self.__data[key]
-	
+
 	if old ~= nil and (typeof(old) ~= "number" or old%1 ~= 0) then
 		if YIELD_TIME_MAX > 0 then
 			wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 		end
 		error("IncrementAsync rejected with error: cannot increment non-integer value", 2)
 	end
-	
+
 	delta = delta and math.floor(delta + .5) or 1
-	
+
 	self.__data[key] = (old or 0) + delta
-	
+
 	if old == nil or delta ~= 0 then
 		self.__event:Fire(key, self.__data[key])
 	end
-	
+
 	local retValue = self.__data[key]
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return retValue
-	
+
 end
 
 function DataStore:RemoveAsync(key)
@@ -369,20 +369,20 @@ function DataStore:RemoveAsync(key)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'RemoveAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local value = deepcopy(self.__data[key])
 	self.__data[key] = nil
-	
+
 	if value ~= nil then
 		self.__event:Fire(key, nil)
 	end
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return value
-	
+
 end
 
 function DataStore:SetAsync(key, value)
@@ -395,7 +395,7 @@ function DataStore:SetAsync(key, value)
 	elseif value == nil or type(value) == "function" or type(value) == "userdata" or type(value) == "thread" then
 		error("bad argument #2 to 'SetAsync' (cannot store values of type " .. typeof(value) .. ")", 2)
 	end
-	
+
 	if typeof(value) == "table" then
 		local isValid, keyPath, reason = scanValidity(value)
 		if not isValid then
@@ -412,16 +412,16 @@ function DataStore:SetAsync(key, value)
 			error("bad argument #2 to 'SetAsync' (data length exceeds " .. MAX_LENGTH_DATA .. " character limit)", 2)
 		end
 	end
-	
+
 	if typeof(value) == "table" or value ~= self.__data[key] then
 		self.__data[key] = deepcopy(value)
 		self.__event:Fire(key, self.__data[key])
 	end
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 end
 
 function DataStore:UpdateAsync(key, transformFunction)
@@ -434,13 +434,13 @@ function DataStore:UpdateAsync(key, transformFunction)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'UpdateAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local value = transformFunction(deepcopy(self.__data[key]))
-	
+
 	if value == nil or type(value) == "function" or type(value) == "userdata" or type(value) == "thread" then
 		error("bad argument #2 to 'UpdateAsync' (resulting value is of type " .. typeof(value) .. " that cannot be stored)", 2)
-	end 
-	
+	end
+
 	if typeof(value) == "table" then
 		local isValid, keyPath, reason = scanValidity(value)
 		if not isValid then
@@ -457,20 +457,20 @@ function DataStore:UpdateAsync(key, transformFunction)
 			error("bad argument #2 to 'UpdateAsync' (resulting data length exceeds " .. MAX_LENGTH_DATA .. " character limit)", 2)
 		end
 	end
-	
+
 	if typeof(value) == "table" or value ~= self.__data[key] then
 		self.__data[key] = deepcopy(value)
 		self.__event:Fire(key, self.__data[key])
 	end
-	
+
 	local retValue = deepcopy(value)
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return retValue
-	
+
 end
 
 function DataStore:ExportToJSON()
@@ -478,9 +478,9 @@ function DataStore:ExportToJSON()
 end
 
 function DataStore:ImportFromJSON(json, verbose)
-	
+
 	local content
-	
+
 	if typeof(json) == "string" then
 		local parsed, value = pcall(function() return HttpService:JSONDecode(json) end)
 		if not parsed then
@@ -492,11 +492,11 @@ function DataStore:ImportFromJSON(json, verbose)
 	else
 		error("bad argument #1 to 'ImportFromJSON' (string or table expected, got " .. typeof(json) .. ")", 2)
 	end
-	
+
 	if verbose ~= nil and typeof(verbose) ~= "boolean" then
 		error("bad argument #2 to 'ImportFromJSON' (boolean expected, got " .. typeof(verbose) .. ")", 2)
 	end
-	
+
 	importPairsFromTable(
 		content,
 		self.__data,
@@ -507,7 +507,7 @@ function DataStore:ImportFromJSON(json, verbose)
 			or "GlobalDataStore"),
 		false
 	)
-	
+
 end
 
 -- DataStorePages implementation:
@@ -524,18 +524,18 @@ function DataStorePages:GetCurrentPage()
 end
 
 function DataStorePages:AdvanceToNextPageAsync()
-	
+
 	if self.IsFinished then
 		return
 	end
-	
+
 	self.__currentpage = self.__currentpage + 1
 	self.IsFinished = #self.__results <= self.__currentpage * self.__pagesize
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 end
 
 -- OrderedDataStore implementation:
@@ -553,7 +553,7 @@ function OrderedDataStore:OnUpdate(key, callback)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'OnUpdate' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	return self.__event.Event:connect(function(k, v)
 		if k == key then
 			if YIELD_TIME_UPDATE_MAX > 0 then
@@ -562,7 +562,7 @@ function OrderedDataStore:OnUpdate(key, callback)
 			callback(deepcopy(v))
 		end
 	end)
-	
+
 end
 
 function OrderedDataStore:GetAsync(key)
@@ -573,15 +573,15 @@ function OrderedDataStore:GetAsync(key)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'GetAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local retValue = self.__data[key]
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return retValue
-	
+
 end
 
 function OrderedDataStore:IncrementAsync(key, delta)
@@ -594,18 +594,18 @@ function OrderedDataStore:IncrementAsync(key, delta)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'IncrementAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local old = self.__data[key]
-	
+
 	if old ~= nil and (typeof(old) ~= "number" or old%1 ~= 0) then
 		if YIELD_TIME_MAX > 0 then
 			wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 		end
 		error("IncrementAsync rejected with error: cannot increment non-integer value", 2)
 	end
-	
+
 	delta = delta and math.floor(delta + .5) or 1
-	
+
 	if old == nil then
 		self.__data[key] = delta
 		self.__ref[key] = {Key = key, Value = self.__data[key]}
@@ -618,15 +618,15 @@ function OrderedDataStore:IncrementAsync(key, delta)
 		self.__changed = true
 		self.__event:Fire(key, self.__data[key])
 	end
-	
+
 	local retValue = self.__data[key]
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return retValue
-	
+
 end
 
 function OrderedDataStore:RemoveAsync(key)
@@ -637,9 +637,9 @@ function OrderedDataStore:RemoveAsync(key)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'RemoveAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local value = self.__data[key]
-	
+
 	if value ~= nil then
 		self.__data[key] = nil
 		self.__ref[key] = nil
@@ -651,13 +651,13 @@ function OrderedDataStore:RemoveAsync(key)
 		end
 		self.__event:Fire(key, nil)
 	end
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return value
-	
+
 end
 
 function OrderedDataStore:SetAsync(key, value)
@@ -672,9 +672,9 @@ function OrderedDataStore:SetAsync(key, value)
 	elseif value%1 ~= 0 then
 		error("bad argument #2 to 'SetAsync' (cannot store non-integer values in OrderedDataStore)", 2)
 	end
-	
+
 	local old = self.__data[key]
-	
+
 	if old == nil then
 		self.__data[key] = value
 		self.__ref[key] = {Key = key, Value = value}
@@ -687,13 +687,13 @@ function OrderedDataStore:SetAsync(key, value)
 		self.__changed = true
 		self.__event:Fire(key, self.__data[key])
 	end
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return value
-	
+
 end
 
 function OrderedDataStore:UpdateAsync(key, transformFunction)
@@ -706,15 +706,15 @@ function OrderedDataStore:UpdateAsync(key, transformFunction)
 	elseif #key > MAX_LENGTH_KEY then
 		error("bad argument #1 to 'UpdateAsync' (key name exceeds " .. MAX_LENGTH_KEY .. " character limit)", 2)
 	end
-	
+
 	local value = transformFunction(self.__data[key])
-	
+
 	if type(value) ~= "number" or value%1 ~= 0 then
 		error("bad argument #2 to 'UpdateAsync' (resulting value is a non-integer which can't be stored in OrderedDataStore)", 2)
 	end
-	
+
 	local old = self.__data[key]
-	
+
 	if old == nil then
 		self.__data[key] = value
 		self.__ref[key] = {Key = key, Value = value}
@@ -727,13 +727,13 @@ function OrderedDataStore:UpdateAsync(key, transformFunction)
 		self.__changed = true
 		self.__event:Fire(key, self.__data[key])
 	end
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return value
-	
+
 end
 
 function OrderedDataStore:GetSortedAsync(ascending, pagesize, minValue, maxValue)
@@ -742,12 +742,12 @@ function OrderedDataStore:GetSortedAsync(ascending, pagesize, minValue, maxValue
 	elseif typeof(pagesize) ~= "number" then
 		error("bad argument #2 to 'GetSortedAsync' (number expected, got " .. typeof(pagesize) .. ")", 2)
 	end
-	
+
 	pagesize = math.floor(pagesize + .5)
 	if pagesize <= 0 or pagesize > MAX_PAGE_SIZE then
 		error("bad argument #2 to 'GetSortedAsync' (page size must be an integer above 0 and below " .. MAX_PAGE_SIZE .. ")", 2)
 	end
-	
+
 	if minValue ~= nil then
 		if typeof(minValue) ~= "number" then
 			error("bad argument #3 to 'GetSortedAsync' (number expected, got " .. typeof(minValue) .. ")", 2)
@@ -757,7 +757,7 @@ function OrderedDataStore:GetSortedAsync(ascending, pagesize, minValue, maxValue
 	else
 		minValue = -math.huge
 	end
-	
+
 	if maxValue ~= nil then
 		if typeof(maxValue) ~= "number" then
 			error("bad argument #4 to 'GetSortedAsync' (number expected, got " .. typeof(maxValue) .. ")", 2)
@@ -767,21 +767,21 @@ function OrderedDataStore:GetSortedAsync(ascending, pagesize, minValue, maxValue
 	else
 		maxValue = math.huge
 	end
-	
+
 	if minValue > maxValue then
 		if YIELD_TIME_MAX > 0 then
 			wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 		end
 		error("GetSortedAsync rejected with error: minimum threshold is higher than maximum threshold", 2)
 	end
-	
+
 	if self.__changed then
 		table.sort(self.__sorted, function(a,b) return a.Value < b.Value end)
 		self.__changed = false
 	end
-	
+
 	local results = {}
-	
+
 	if ascending then
 		local i = 1
 		while self.__sorted[i] and self.__sorted[i].Value < minValue do
@@ -801,18 +801,18 @@ function OrderedDataStore:GetSortedAsync(ascending, pagesize, minValue, maxValue
 			i = i - 1
 		end
 	end
-	
+
 	if YIELD_TIME_MAX > 0 then
 		wait(rand:NextNumber(YIELD_TIME_MIN, YIELD_TIME_MAX))
 	end
-	
+
 	return setmetatable({
 		__currentpage = 1;
 		__pagesize = pagesize;
 		__results = results;
 		IsFinished = (#results <= pagesize);
 	}, DataStorePages)
-	
+
 end
 
 function OrderedDataStore:ExportToJSON()
@@ -820,9 +820,9 @@ function OrderedDataStore:ExportToJSON()
 end
 
 function OrderedDataStore:ImportFromJSON(json, verbose)
-	
+
 	local content
-	
+
 	if typeof(json) == "string" then
 		local parsed, value = pcall(function() return HttpService:JSONDecode(json) end)
 		if not parsed then
@@ -834,7 +834,7 @@ function OrderedDataStore:ImportFromJSON(json, verbose)
 	else
 		error("bad argument #1 to 'ImportFromJSON' (string or table expected, got " .. typeof(json) .. ")", 2)
 	end
-	
+
 	importPairsFromTable(
 		content,
 		self.__data,
@@ -843,7 +843,7 @@ function OrderedDataStore:ImportFromJSON(json, verbose)
 		("OrderedDataStore > %s > %s"):format(self.__name, self.__scope),
 		true
 	)
-	
+
 end
 
 -- MockDataStoreService implementation:
@@ -855,7 +855,7 @@ local function makeGetWrapper(methodName, getObject, isGlobal) -- Helper functio
 		if not game:GetService("RunService"):IsServer() then
 			error("DataStore can't be accessed from client", 2)
 		end
-		
+
 		if isGlobal then
 			return getObject()
 		else
@@ -874,7 +874,7 @@ local function makeGetWrapper(methodName, getObject, isGlobal) -- Helper functio
 			end
 			return getObject(name, scope or "global")
 		end
-		
+
 	end
 end
 
@@ -930,7 +930,7 @@ MockDataStoreService.GetOrderedDataStore = makeGetWrapper(
 				__scope = scope;
 				__data = Data.OrderedDataStore[name][scope]; -- Mapping from <key> to <value>
 				__sorted = {}; -- List of {Key = <key>, Value = <value>} pairs
-				__ref = {}; -- Mapping from <key> to corresponding {Key = <key>, Value = <value>} entry in __sorted 
+				__ref = {}; -- Mapping from <key> to corresponding {Key = <key>, Value = <value>} entry in __sorted
 				__changed = false; -- Whether __sorted is guaranteed sorted at the moment
 				__event = Instance.new("BindableEvent"); -- For OnUpdate
 			}
@@ -947,21 +947,24 @@ local budgetMapping = {
 	[Enum.DataStoreRequestType.SetIncrementAsync] = 60;
 	[Enum.DataStoreRequestType.SetIncrementSortedAsync] = 60;
 	[Enum.DataStoreRequestType.UpdateAsync] = 60;
-	Default = 0;
 }
 
+local DataStoreRequestTypes = {}
+
+for _, Enumerator in ipairs(Enum.DataStoreRequestType:GetEnumItems()) do
+	DataStoreRequestTypes[Enumerator] = Enumerator
+	DataStoreRequestTypes[Enumerator.Name] = Enumerator
+	DataStoreRequestTypes[Enumerator.Value] = Enumerator
+end
+
 function MockDataStoreService:GetRequestBudgetForRequestType(requestType)
-	
-	if typeof(requestType) ~= "EnumItem" or requestType.EnumType ~= Enum.DataStoreRequestType then
-		error("bad argument #1 to 'GetRequestBudgetForRequestType' (DataStoreRequestType expected, got " .. typeof(requestType) .. ")", 2)
-	end
-	
-	return budgetMapping[requestType] or budgetMapping.Default
-	
+	return budgetMapping[
+		DataStoreRequestTypes[requestType] or error("bad argument #1 to 'GetRequestBudgetForRequestType' (unable to cast " .. typeof(requestType) .. " " .. tostring(requestType) .. " to DataStoreRequestType)", 2)
+	] or 0
 end
 
 function MockDataStoreService:ExportToJSON()
-	
+
 	local orderedData = {}
 	local numOrdered = 0
 	for name, scopes in pairs(Data.OrderedDataStore) do
@@ -984,7 +987,7 @@ function MockDataStoreService:ExportToJSON()
 			numOrdered = numOrdered + 1
 		end
 	end
-	
+
 	local regularData = {}
 	local numRegular = 0
 	for name, scopes in pairs(Data.DataStore) do
@@ -1007,15 +1010,15 @@ function MockDataStoreService:ExportToJSON()
 			numRegular = numRegular + 1
 		end
 	end
-	
+
 	local globalHasItems = false
 	for _, _ in pairs(Data.GlobalDataStore) do
 		globalHasItems = true
 		break
 	end
-	
+
 	local export = {}
-	
+
 	if globalHasItems then
 		export.GlobalDataStore = Data.GlobalDataStore
 	end
@@ -1025,15 +1028,15 @@ function MockDataStoreService:ExportToJSON()
 	if numRegular > 0 then
 		export.DataStore = regularData
 	end
-	
+
 	return HttpService:JSONEncode(export)
-	
+
 end
 
 function MockDataStoreService:ImportFromJSON(json, verbose)
-	
+
 	local content
-	
+
 	if typeof(json) == "string" then
 		local parsed, value = pcall(function() return HttpService:JSONDecode(json) end)
 		if not parsed then
@@ -1045,24 +1048,24 @@ function MockDataStoreService:ImportFromJSON(json, verbose)
 	else
 		error("bad argument #1 to 'ImportFromJSON' (string or table expected, got " .. typeof(json) .. ")", 2)
 	end
-	
+
 	local warnFunc = warn
 	if verbose == false then
 		warnFunc = function() end
 	end
-	
+
 	if typeof(content.GlobalDataStore) == "table" then
 		importPairsFromTable(content.GlobalDataStore, Data.GlobalDataStore, warnFunc, "ImportFromJSON", "GlobalDataStore", false)
 	end
-	
+
 	if typeof(content.DataStore) == "table" then
 		importDataStoresFromTable(content.DataStore, Data.DataStore, warnFunc, "ImportFromJSON", "DataStore", false)
 	end
-	
+
 	if typeof(content.OrderedDataStore) == "table" then
 		importDataStoresFromTable(content.OrderedDataStore, Data.OrderedDataStore, warnFunc, "ImportFromJSON", "OrderedDataStore", true)
 	end
-	
+
 end
 
 return MockDataStoreService


### PR DESCRIPTION
By default, any parameter expecting a Roblox Enum may pass in a corresponding Value or Name of a valid enum instead, and it will be cast to the proper Enum internally.