### PR TITLE
Add OnClose budgeting logic based on engineer description

### DIFF
--- a/lib/MockDataStoreService/MockDataStoreConstants.lua
+++ b/lib/MockDataStoreService/MockDataStoreConstants.lua
@@ -63,6 +63,9 @@ return {
         MAX_FACTOR = 3;
     };
 
+    BUDGET_BASE = 60;               -- Modifiers used for budget increases on OnClose
+    BUDGET_ONCLOSE_BASE = 150;
+
     BUDGET_UPDATE_INTERVAL = 1.0;	-- Time interval in seconds at which budgets are updated (do not put too low)
 
 }

--- a/lib/MockDataStoreService/MockDataStoreManager.lua
+++ b/lib/MockDataStoreService/MockDataStoreManager.lua
@@ -131,6 +131,17 @@ if RunService:IsServer() then
 			end
 		end
 	end)
+
+	game:BindToClose(function()
+		for requestType, const in pairs(ConstantsMapping) do
+			Budgets[requestType] = math.max(Budgets[requestType], Constants.BUDGET_ONCLOSE_BASE * (const.RATE / ))
+		end
+		Budgets[Enum.DataStoreRequestType.UpdateAsync] = math.min(
+			Budgets[Enum.DataStoreRequestType.GetAsync],
+			Budgets[Enum.DataStoreRequestType.SetIncrementAsync]
+		)
+	end)
+
 end
 
 function MockDataStoreManager:GetGlobalData()


### PR DESCRIPTION
Adds some extra logic to increase budgets on OnClose (apparently Roblox does this based on a chat I had with an intern)