### PR TITLE
Replaced accurateWait() with task.wait()

### DIFF
--- a/lib/MockDataStoreService/MockDataStoreManager.lua
+++ b/lib/MockDataStoreService/MockDataStoreManager.lua
@@ -98,9 +98,9 @@ if RunService:IsServer() then
 
 	initBudget()
 
-	coroutine.wrap(function() -- Thread that increases budgets and de-throttles requests periodically
+	task.spawn(function() -- Thread that increases budgets and de-throttles requests periodically
 		local lastCheck = tick()
-		while Utils.accurateWait(Constants.BUDGET_UPDATE_INTERVAL) do
+		while task.wait(Constants.BUDGET_UPDATE_INTERVAL) do
 			local now = tick()
 			local dt = (now - lastCheck) / 60
 			lastCheck = now
@@ -134,7 +134,7 @@ if RunService:IsServer() then
 				end
 			end
 		end
-	end)()
+	end)
 
 	game:BindToClose(function()
 		for requestType, const in pairs(ConstantsMapping) do

--- a/lib/MockDataStoreService/MockDataStoreUtils.lua
+++ b/lib/MockDataStoreService/MockDataStoreUtils.lua
@@ -254,20 +254,9 @@ local function preprocessKey(key)
 	return key
 end
 
-local function accurateWait(dt)
-	dt = math.max(0, dt)
-	local left = dt
-
-	while left > 0 do
-		left = left - RunService.Heartbeat:Wait()
-	end
-
-	return dt - left
-end
-
 local function simulateYield()
 	if Constants.YIELD_TIME_MAX > 0 then
-		accurateWait(rand:NextNumber(Constants.YIELD_TIME_MIN, Constants.YIELD_TIME_MAX))
+		task.wait(rand:NextNumber(Constants.YIELD_TIME_MIN, Constants.YIELD_TIME_MAX))
 	end
 end
 
@@ -286,7 +275,6 @@ MockDataStoreUtils.getStringPath = getStringPath
 MockDataStoreUtils.importPairsFromTable = importPairsFromTable
 MockDataStoreUtils.prepareDataStoresForExport = prepareDataStoresForExport
 MockDataStoreUtils.preprocessKey = preprocessKey
-MockDataStoreUtils.accurateWait = accurateWait
 MockDataStoreUtils.simulateYield = simulateYield
 MockDataStoreUtils.simulateErrorCheck = simulateErrorCheck
 

--- a/lib/MockDataStoreService/MockGlobalDataStore.lua
+++ b/lib/MockDataStoreService/MockGlobalDataStore.lua
@@ -46,7 +46,7 @@ function MockGlobalDataStore:OnUpdate(key, callback)
 	return self.__event.Event:Connect(function(k, v)
 		if k == key then
 			if Constants.YIELD_TIME_UPDATE_MAX > 0 then
-				Utils.accurateWait(rand:NextNumber(Constants.YIELD_TIME_UPDATE_MIN, Constants.YIELD_TIME_UPDATE_MAX))
+				task.wait(rand:NextNumber(Constants.YIELD_TIME_UPDATE_MIN, Constants.YIELD_TIME_UPDATE_MAX))
 			end
 			callback(v) -- v was implicitly deep-copied
 		end

--- a/lib/MockDataStoreService/MockOrderedDataStore.lua
+++ b/lib/MockDataStoreService/MockOrderedDataStore.lua
@@ -47,7 +47,7 @@ function MockOrderedDataStore:OnUpdate(key, callback)
 	return self.__event.Event:Connect(function(k, v)
 		if k == key then
 			if Constants.YIELD_TIME_UPDATE_MAX > 0 then
-				Utils.accurateWait(rand:NextNumber(Constants.YIELD_TIME_UPDATE_MIN, Constants.YIELD_TIME_UPDATE_MAX))
+				task.wait(rand:NextNumber(Constants.YIELD_TIME_UPDATE_MIN, Constants.YIELD_TIME_UPDATE_MAX))
 			end
 			callback(v) -- v was implicitly deep-copied
 		end


### PR DESCRIPTION
Implements the new `task` library.
* Replaces `accurateWait()` with `task.wait()`
* Replaces `coroutine.wrap()` with `task.spawn()`