### PR TITLE
Add compatibility with wally

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,25 @@
+name : Publish system packages to registry
+on:
+  release:
+    types: [published]
+
+jobs:
+  package-publish:
+    name: Publish packages to wally registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Setup foreman
+        uses: rojo-rbx/setup-foreman@62bc697705339a6049f74c9d0ff6d39cffc993e5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish wally packages
+        env:
+          WALLY_AUTH: ${{ secrets.WALLY_AUTH }}
+        run: |
+          mkdir -p ~/.wally
+          echo "$WALLY_AUTH" > ~/.wally/auth.toml
+          wally publish

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /*.rbxmx
 /*.rbxm
 /*.rbxl
+/*.lock
+/Packages

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,2 +1,3 @@
 [tools]
 rojo = {source = "Roblox/rojo", version = "6.0.0-rc.1"}
+wally = {source = "upliftgames/wally", version = "=0.3.1"}

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,8 @@
+[package]
+name = "buildthomas/mockdatastoreservice"
+description = "Emulation of Roblox's DataStoreService for seamless offline development & testing"
+version = "1.0.2"
+authors = ["buildthomas"]
+realm = "shared"
+license = "Apache-2.0"
+registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
This PR makes this library compatible with [wally](https://wally.run/), a popular package manager for the Roblox software ecosystem.

The following changes have been made:
- `wally.toml` configuration added, which describes the package
- `publish-package` github action added, which automatically publishes this library to the wally package registry whenever a new github release is created
- Temporary files created by wally have been added to `.gitignore` for convenience

The `publish-package` action requires a repository secret named `WALLY_AUTH` to be created, with its value being your wally token. To generate a wally token, the following steps must be taken:
1) Install wally. This can be a manual install, or an install via `foreman`
2) Run `wally login`. A github tab will open asking if it is OK for wally to read your account username & ID, which is info wally uses to generate a token
3) Once logged in, open `<userdirectory>\.wally\auth.toml` and copy that file's contents
4) Create a `WALLY_AUTH` secret in this repository, and paste the file's contents as its value
5) All set! Save the secret and the `publish-package` action should work.

For first-time package publish, it might be a good idea to bump this library's version to `1.0.3` with a new release to trigger the github action. Remember to edit `wally.toml`'s `version` field!